### PR TITLE
Remove incremental review feature

### DIFF
--- a/.github/ai-review.yml
+++ b/.github/ai-review.yml
@@ -70,11 +70,6 @@ prSizeWarning:
   maxLines: 1000            # Warn if total changes exceed this
   maxFiles: 30              # Warn if number of files exceeds this
 
-# Incremental Reviews - only review new commits after first review
-incrementalReview:
-  enabled: true
-  # First review is always full, subsequent reviews are incremental
-
 # Review Caching - skip re-review if commit already reviewed
 caching:
   enabled: true


### PR DESCRIPTION
Incremental reviews were removed because they introduced several issues:
- Critical issues could be "forgotten" after the first review
- Context loss when reviewing small diffs
- Comment positioning failures (files not in PR diff)
- False confidence ("no issues" didn't mean "PR is safe")

The cost savings weren't worth the security risks. Full PR reviews are now always performed for each push.

Removed:
- incrementalReview config option
- getLastReviewedCommit() function
- getIncrementalDiff() function
- isIncremental parameter from various functions
- Incremental-related metrics and logging
- Incremental-specific messaging in summary